### PR TITLE
Remove react-imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,25 +1,24 @@
 {
-    "env": {
-        "browser": true,
-        "es2021": true
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
     },
-    "extends": [
-        "eslint:recommended",
-        "plugin:react/recommended",
-        "plugin:@typescript-eslint/recommended"
-    ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaFeatures": {
-            "jsx": true
-        },
-        "ecmaVersion": "latest",
-        "sourceType": "module"
-    },
-    "plugins": [
-        "react",
-        "@typescript-eslint"
-    ],
-    "rules": {
-    }
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": ["react", "@typescript-eslint"],
+  "rules": {
+    "react/jsx-uses-react": "off",
+    "react/react-in-jsx-scope": "off"
+  }
 }

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Outlet } from 'react-router-dom'
 import { Header } from './components/Header'
 import { Footer } from './components/Footer'

--- a/src/components/Buttons/index.tsx
+++ b/src/components/Buttons/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { ButtonStyle, ButtonText } from "./styles";
 
 

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import * as S from './styles'
 import {StyledLink} from '../Link/styles'
 

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import * as S from "./styles";
 import Logo from "../../assets/jardi-logo-trans.png";
 import Login from "../../assets/login.png";

--- a/src/components/ModalForm/index.tsx
+++ b/src/components/ModalForm/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useState } from "react";
 import * as S from "../ModalForm/styles";
 import Logo from "../../assets/jardi-logo-trans.png";

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { StyledInput, Input } from "./styles";
 
 

--- a/src/components/SignUpForm/index.tsx
+++ b/src/components/SignUpForm/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useState } from "react";
 import * as S from "../SignUpForm/styles";
 import Logo from "../../assets/jardi-logo-trans.png";

--- a/src/components/Uploader/index.tsx
+++ b/src/components/Uploader/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 
 import UploadIcon from "../../assets/upload-icon.png";
 import * as S from "./styles";

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,16 +1,10 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import HomePage from './pages/HomePage'
-import {
-  createBrowserRouter,
-  RouterProvider,
-} from "react-router-dom";
+import React from "react";
+import ReactDOM from "react-dom/client";
+import HomePage from "./pages/HomePage";
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
 
-import { Layout } from './Layout'
-import { GlobalStyle } from './GlobalStyles';
-
-
-
+import { Layout } from "./Layout";
+import { GlobalStyle } from "./GlobalStyles";
 
 const router = createBrowserRouter([
   {
@@ -25,9 +19,9 @@ const router = createBrowserRouter([
   },
 ]);
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <GlobalStyle />
     <RouterProvider router={router} />
   </React.StrictMode>
-)
+);

--- a/src/pages/HomePage/components/CTA/index.tsx
+++ b/src/pages/HomePage/components/CTA/index.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react'
+import {useState} from 'react'
 import { Button } from '../../../../components/Buttons'
 import { Modal } from '../../../../components/ModalForm'
 import { HomePageWordings, ButtonWordings } from '../../../../wordings'

--- a/src/pages/HomePage/components/Carousel/CarouselItem.tsx
+++ b/src/pages/HomePage/components/Carousel/CarouselItem.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { CarouselItemType } from '../../../../type';
 
 export type Props = CarouselItemType

--- a/src/pages/HomePage/components/Carousel/CarouselSwipe.tsx
+++ b/src/pages/HomePage/components/Carousel/CarouselSwipe.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {Carousel} from "react-bootstrap";
 
 import { CarouselItemType } from '../../../../type';

--- a/src/pages/HomePage/components/Carousel/index.tsx
+++ b/src/pages/HomePage/components/Carousel/index.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { CarouselSwipe } from "./CarouselSwipe";
 
 

--- a/src/pages/HomePage/components/TitleCard/index.tsx
+++ b/src/pages/HomePage/components/TitleCard/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import * as S from "./styles";
 import { HomePageWordings } from "../../../../wordings";
 //import Chicken from "../../../../assets/chicken-icon.png";

--- a/src/pages/HomePage/index.tsx
+++ b/src/pages/HomePage/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 
 import { CTA } from "./components/CTA";
 

--- a/src/stories/Footer.stories.tsx
+++ b/src/stories/Footer.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ComponentMeta } from '@storybook/react';
 
 import { Footer } from '../components/Footer';

--- a/src/stories/Header.stories.tsx
+++ b/src/stories/Header.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ComponentMeta } from '@storybook/react';
 
 import { Header } from '../components/Header';


### PR DESCRIPTION
# ℹ️ Context
[RELATED TICKET](put_your_ticket_url_here)

No need to import React in modules nowadays. Removed unnecessary imports and turning off corresponding eslint-rule
