### PR TITLE
fix: pagination offset on gardens

### DIFF
--- a/src/pages/Gardens/index.tsx
+++ b/src/pages/Gardens/index.tsx
@@ -85,12 +85,12 @@ export const GardenPage: React.FC = () => {
         ))}
       </div>
       {data?.next && !isPreviousData && (
-        <PageButton onClick={(): void => setOffset(offset + 2)}>
+        <PageButton onClick={(): void => setOffset(offset + 10)}>
           Page suivante
         </PageButton>
       )}
       {data?.previous && (
-        <PageButton onClick={(): void => setOffset(offset - 2)}>
+        <PageButton onClick={(): void => setOffset(offset - 10)}>
           Page précédente
         </PageButton>
       )}


### PR DESCRIPTION
# ℹ️ Context
[43](https://github.com/JardiPotes/front-garden/issues/43)

Change the `offset` calculation from 2 to 10.

## ❓ Type of change

* 🐛 Bug fix (non-breaking change which fixes an issue)

