### PR TITLE
fix: link between garden thumb and profile page

### DIFF
--- a/src/pages/Gardens/components/Thumb/index.tsx
+++ b/src/pages/Gardens/components/Thumb/index.tsx
@@ -16,23 +16,29 @@ export const GardenThumb: React.FC<GardenThumb> = ({ garden }) => {
     zipcode,
     image = defaultImage,
     user_image = defaultUserImage,
+    user_id
   } = garden;
-  const adressLink = `https://maps.google.com/maps?q=${address}+${zipcode}`;
+  const adressLink =
+    address && `https://maps.google.com/maps?q=${address}+${zipcode}`;
 
   return (
     <S.Wrapper>
       <S.Image src={image} />
       <S.InfoWrapper>
-        <div>
+        <S.RouterLink to={`../profile/${user_id}`}>
           <S.TitleWrapper>
             <S.Icon src={user_image} /> <div>{title}</div>
           </S.TitleWrapper>
           <div>{description}</div>
-        </div>
-        <S.Address>
-          <S.Pin src={pin} />
-          <a href={adressLink}>{address}</a>
-        </S.Address>
+        </S.RouterLink>
+        {adressLink && (
+          <S.Address>
+            <a href={adressLink}>
+              <S.Pin src={pin} />
+              {address}
+            </a>
+          </S.Address>
+        )}
       </S.InfoWrapper>
     </S.Wrapper>
   );

--- a/src/pages/Gardens/components/Thumb/styles.tsx
+++ b/src/pages/Gardens/components/Thumb/styles.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { Link } from "react-router-dom";
 
 export const Wrapper = styled.div`
   background-color: #fcf9f9;
@@ -35,6 +36,11 @@ export const TitleWrapper = styled.div`
   justify-content: space-between;
   gap: 4px;
   margin-bottom: 10px;
+`;
+
+export const RouterLink = styled(Link)`
+  text-decoration: none;
+  color: inherit;
 `;
 
 export const Image = styled.img`


### PR DESCRIPTION
# ℹ️ Context
Just added a link on garden thumbs so they redirect to user profile. Also removed google maps link when no location is provided. 

## ❓ Type of change
Please delete options that are not relevant.

* 🐛 Bug fix (non-breaking change which fixes an issue)