### PR TITLE
fix: messages appear without reloading

### DIFF
--- a/src/pages/Messages/components/Conversation/index.tsx
+++ b/src/pages/Messages/components/Conversation/index.tsx
@@ -42,7 +42,8 @@ export default function Conversation({
   const {
     register,
     handleSubmit,
-    formState: { errors }
+    formState: { errors },
+    setValue
   } = useForm();
 
   const { error, isLoading, refetch, data, isPreviousData }: QueryArgs =
@@ -60,9 +61,9 @@ export default function Conversation({
       refetchInterval: 30000
     });
 
-  // useEffect(() => {
-  //   refetch();
-  // }, [convId, currentConv]);
+  useEffect(() => {
+    refetch();
+  }, [convId, currentConv]);
 
   const { isLoading: isCreatingMessage, mutate: createMessage } = useMutation(
     async (data: CreateMessageArgs) => {
@@ -75,6 +76,7 @@ export default function Conversation({
     {
       onSuccess: () => {
         refetch();
+        setValue("message", "");
       },
       onError: (err: AxiosError) => {
         // eslint-disable-next-line no-console


### PR DESCRIPTION
# ℹ️ Context
Two small fixes on the messages page : 
- messages appear as soon as user arrives on the messages page
- message input is reinitialized when message is sent

## ❓ Type of change
Please delete options that are not relevant.

* 🐛 Bug fix (non-breaking change which fixes an issue)


# 📸 Screenshots
N/A

# 🎯 Approach
Please summarize your approaches for the given issue to help reviewers better understand how you organize your code.
